### PR TITLE
Fix broken post icons

### DIFF
--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="{{ '/css/prism-base16-monokai.dark.css' | url }}">
     <link rel="alternate" href="{{ metadata.feed.path | url }}" type="application/atom+xml" title="{{ metadata.title }}">
     <link href="https://fonts.googleapis.com/css?family=Nunito:400,700|Saira+Extra+Condensed:400,600&display=swap" rel="stylesheet">
-    <script src="https://kit.fontawesome.com/4494cdfa79.js" crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
   </head>
   <body>
     <header>

--- a/posts/Eleventy-and-Netflify-are-my-new-jam.md
+++ b/posts/Eleventy-and-Netflify-are-my-new-jam.md
@@ -6,7 +6,7 @@ author: Michael Boeke
 tags:
  - Code
 layout: layouts/post.njk
-icon: boombox
+icon: volume-up
 ---
 
 I recently found myself in the job market for the first time in a while, and it was just the kick I needed to embark on a long-overdue overhaul of my website and blog (the very one you are reading).

--- a/posts/How-to-get-designers-to-make-your-open-source-project-awesome.md
+++ b/posts/How-to-get-designers-to-make-your-open-source-project-awesome.md
@@ -7,7 +7,7 @@ tags:
   - design
   - open source
 layout: layouts/post.njk
-icon: alicorn
+icon: hand-sparkles
 ---
 
 Like many designers, I use open source software, believe in the open source ethos, and would love to help make open source software look better and be easier to use. A lot of open-source projects are focused on the back-end, and don’t require a ton of UI/UX design, but it seems that there are more web apps popping up these days.

--- a/posts/Self-hosting-Google-web-fonts.md
+++ b/posts/Self-hosting-Google-web-fonts.md
@@ -8,7 +8,7 @@ tags:
   - web fonts
 layout: layouts/post.njk
 image: /img/woff-comparison.png
-icon: font-case
+icon: font
 ---
 When using web fonts from Google Fonts, it generally makes sense to take advantage of the files hosted on Google’s CDN. However, there are legitimate reasons to host fonts yourself sometimes. If you need to keep your tinfoil hat on at all times, because your site attracts bad guys, you may not want to take the risk of running code from a third party, even one as respected and august as The Google. That is indeed the case at Braintree, where we decided to host fonts on our own servers.
 

--- a/posts/quantum-nature-of-sales.md
+++ b/posts/quantum-nature-of-sales.md
@@ -6,7 +6,7 @@ author: Michael Boeke
 tags:
   - startups
 layout: layouts/post.njk
-icon: wave-sine
+icon: wave-square
 ---
 When we were first starting up Backstop, we would watch eagerly as each new customer advanced through the sales pipeline, and tear our hair out as deals seemed to drag on forever. Years later, I still hear the development teams I work with at Braintree asking ”when will deal X be done?” So, I thought it might be useful to write down this explanation I came up with for that early Backstop dev team.
 


### PR DESCRIPTION
Fix broken post icons by switching to Font Awesome 5 Free CDN and replacing Pro-only icons with free equivalents